### PR TITLE
Fix quote form route duplication and resolve build type errors

### DIFF
--- a/app/api/forms/quote/route.ts
+++ b/app/api/forms/quote/route.ts
@@ -34,8 +34,8 @@ export async function POST(req: Request) {
       projectType,
       message,
       honey,
-      consentInfo,      // zorunlu
-      consentContact,   // zorunlu
+      consentInfo, // zorunlu
+      consentContact, // zorunlu
       consentMarketing, // opsiyonel
     } = body ?? {};
 
@@ -90,8 +90,7 @@ export async function POST(req: Request) {
       </p>
     `;
 
-    const text =
-`Hızlı Teklif Formu
+    const text = `Hızlı Teklif Formu
 
 Ad Soyad  : ${_name}
 İletişim  : ${_contact}
@@ -108,137 +107,7 @@ Gönderim: ${whenTR}
 IP: ${ip}
 User-Agent: ${ua}
 
-Not: Veriler yalnızca talebinizin değerlendirilmesi amacıyla işlenir ve sunucuda kalıcı saklanmaz.
-`;
-
-    const transporter = mailer();
-    await transporter.sendMail({
-      from: process.env.MAIL_FROM || process.env.SMTP_USER!,
-      to: process.env.MAIL_TO || process.env.SMTP_USER!,
-      subject,
-      text,
-      html,
-      headers: { "X-AYK-Form": "quote" },
-    });
-
-    return NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
-  } catch (err) {
-    console.error("[quote] error:", err);
-    return NextResponse.json({ error: "Mail gönderilemedi." }, { status: 500, headers: { "Cache-Control": "no-store" } });
-  }
-}
-import { NextResponse } from "next/server";
-import nodemailer from "nodemailer";
-
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
-
-type Boolish = boolean | "true" | "on" | "1" | "false" | "0" | undefined | null | string;
-const yes = (v: Boolish) => v === true || v === "true" || v === "on" || v === "1";
-
-const sanitize = (input: unknown, max = 2000) =>
-  String(input ?? "").replace(/\r/g, "").replace(/</g, "&lt;").replace(/>/g, "&gt;").slice(0, max).trim();
-
-const required = (s?: string) => typeof s === "string" && s.trim().length > 0;
-
-function mailer() {
-  const host = process.env.SMTP_HOST!;
-  const port = Number(process.env.SMTP_PORT || 587);
-  const user = process.env.SMTP_USER!;
-  const pass = process.env.SMTP_PASS!;
-  if (!host || !user || !pass) throw new Error("SMTP credentials are missing");
-  return nodemailer.createTransport({ host, port, secure: false, auth: { user, pass } });
-}
-
-export async function POST(req: Request) {
-  try {
-    if (!(req.headers.get("content-type") || "").includes("application/json")) {
-      return NextResponse.json({ error: "Invalid content type" }, { status: 400, headers: { "Cache-Control": "no-store" } });
-    }
-
-    const body = await req.json().catch(() => ({}));
-    const {
-      name,
-      contact,
-      projectType,
-      message,
-      honey,
-      consentInfo,      // zorunlu
-      consentContact,   // zorunlu
-      consentMarketing, // opsiyonel
-    } = body ?? {};
-
-    if (typeof honey === "string" && honey.trim() !== "") {
-      return NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
-    }
-
-    const _name = sanitize(name, 200);
-    const _contact = sanitize(contact, 200);
-    const _type = sanitize(projectType, 200);
-    const _message = sanitize(message, 4000);
-
-    if (!required(_name) || !required(_contact) || !required(_type) || !required(_message)) {
-      return NextResponse.json({ error: "Lütfen gerekli alanları doldurun." }, { status: 400, headers: { "Cache-Control": "no-store" } });
-    }
-
-    if (!yes(consentInfo) || !yes(consentContact)) {
-      return NextResponse.json({ error: "Gerekli aydınlatma ve iletişim onaylarını işaretleyiniz." }, { status: 400, headers: { "Cache-Control": "no-store" } });
-    }
-    const marketingOK = yes(consentMarketing);
-
-    const ua = req.headers.get("user-agent") || "unknown";
-    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || req.headers.get("x-real-ip") || "unknown";
-    const whenTR = new Date().toLocaleString("tr-TR");
-
-    const subjectPrefix = process.env.MAIL_SUBJECT_PREFIX ?? "";
-    const subject = `${subjectPrefix} [TEKLİF] ${_name} – ${_type}`;
-
-    const html = `
-      <h2>Hızlı Teklif Formu</h2>
-      <table style="border-collapse:collapse" cellpadding="6" border="1">
-        <tr><td><b>Ad Soyad</b></td><td>${_name}</td></tr>
-        <tr><td><b>İletişim</b></td><td>${_contact}</td></tr>
-        <tr><td><b>Proje Türü</b></td><td>${_type}</td></tr>
-        <tr><td><b>Mesaj</b></td><td>${_message.replace(/\n/g, "<br/>")}</td></tr>
-      </table>
-      <h3>Onaylar</h3>
-      <ul>
-        <li><b>Aydınlatma/KVKK:</b> Evet</li>
-        <li><b>İletişime Geçilmesine Onay:</b> Evet</li>
-        <li><b>Pazarlama İzni:</b> ${marketingOK ? "Evet" : "Hayır"}</li>
-      </ul>
-      <hr/>
-      <p style="font-size:12px;color:#555">
-        <b>Gönderim:</b> ${whenTR}<br/>
-        <b>IP:</b> ${ip}<br/>
-        <b>User-Agent:</b> ${sanitize(ua, 300)}
-      </p>
-      <p style="font-size:12px;color:#555">
-        Bu e-posta, başvurunun <i>değerlendirilmesi ve fiyat/geri dönüş sağlanması</i> amacıyla oluşturulmuştur.
-        Veriler amaç dışı kullanılmaz ve sunucuda kalıcı saklanmaz.
-      </p>
-    `;
-
-    const text =
-`Hızlı Teklif Formu
-
-Ad Soyad  : ${_name}
-İletişim  : ${_contact}
-Proje Türü: ${_type}
-Mesaj     :
-${_message}
-
-Onaylar
-- Aydınlatma/KVKK: Evet
-- İletişime Geçilmesine Onay: Evet
-- Pazarlama İzni: ${marketingOK ? "Evet" : "Hayır"}
-
-Gönderim: ${whenTR}
-IP: ${ip}
-User-Agent: ${ua}
-
-Not: Veriler yalnızca talebinizin değerlendirilmesi amacıyla işlenir ve sunucuda kalıcı saklanmaz.
-`;
+Not: Veriler yalnızca talebinizin değerlendirilmesi amacıyla işlenir ve sunucuda kalıcı saklanmaz.`;
 
     const transporter = mailer();
     await transporter.sendMail({

--- a/app/hizmetler/page.tsx
+++ b/app/hizmetler/page.tsx
@@ -1,6 +1,7 @@
 import Container from "@/components/Container";
 import { services } from "@/data/services";
 import { Wrench, Cable, Sun, Package, ListChecks, CircuitBoard } from "lucide-react";
+import type { ReactElement } from "react";
 import Link from "next/link";
 
 export const metadata = {
@@ -9,7 +10,7 @@ export const metadata = {
     "Proje danışmanlık & mühendislik, elektrik elektronik taahhüt, elektrik malzemesi satışı, zayıf akım sistemleri, güneş enerji sistemleri ve bakım & servis.",
 };
 
-const iconMap: Record<string, JSX.Element> = {
+const iconMap: Record<string, ReactElement> = {
   "proje-danismanlik-muhendislik": <ListChecks className="w-6 h-6 text-[var(--brand)]" />,
   "elektrik-elektronik-taahhut": <Cable className="w-6 h-6 text-[var(--brand)]" />,
   "elektrik-malzemesi-satisi": <Package className="w-6 h-6 text-[var(--brand)]" />,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,12 +150,16 @@ export default function Page() {
 
         {/* içerik */}
         <div className="relative z-10 max-w-7xl mx-auto px-4 grid min-h-[85vh] content-center">
-          <motion.h1 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }} className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
-            Güvenilir mühendislik, sürdürülebilir enerji, kalıcı değer.
-          </motion.h1>
-          <motion.p initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1, duration: 0.6 }} className="mt-6 text-neutramt-6 text-neutral-700 font-semibold max-w-2xll-700 max-w-2xl">
-            Elektrikte 25+ yıllık deneyim, güçlü mühendislik ve anahtar teslim projeler.
-          </motion.p>
+          <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }}>
+            <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
+              Güvenilir mühendislik, sürdürülebilir enerji, kalıcı değer.
+            </h1>
+          </motion.div>
+          <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1, duration: 0.6 }}>
+            <p className="mt-6 text-neutramt-6 text-neutral-700 font-semibold max-w-2xll-700 max-w-2xl">
+              Elektrikte 25+ yıllık deneyim, güçlü mühendislik ve anahtar teslim projeler.
+            </p>
+          </motion.div>
           <div className="mt-8 flex flex-col sm:flex-row gap-3">
             <a href="#teklif" className="px-5 py-3 rounded-xl bg-neutral-800 text-white hover:bg-[var(--brand)]">Hızlı Teklif Al</a>
             <a href="#projeler" className="px-5 py-3 rounded-xl border border-neutral-300 hover:border-[var(--brand)] hover:text-[var(--brand)]">Projeler</a>

--- a/types/nodemailer.d.ts
+++ b/types/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module "nodemailer";


### PR DESCRIPTION
## Summary
- rebuild the quote form API handler to remove the duplicated block and correctly define the text payload
- add a minimal `nodemailer` module declaration and align the hizmetler icon map typing with React elements
- adjust the homepage hero motion markup to avoid strict JSX typing errors during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d536cdab94832fa2d33c087b7d42a6