### PR TITLE
Update experience messaging and responsive home logo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -170,7 +170,7 @@ export default function Page() {
           <div className="mt-10 overflow-hidden">
             <div className="flex gap-4 whitespace-nowrap animate-[featureScroll_30s_linear_infinite]">
               {[
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -178,7 +178,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -186,7 +186,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -194,7 +194,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
                 <img
                   src="/assets/AYKlogo.webp"
                   alt="AYK Logo"
-                  className="h-20 w-auto"
+                  className="h-12 w-auto md:h-20"
                 />
               </Link>
 


### PR DESCRIPTION
## Summary
- update homepage feature highlights to reference 25+ years of experience consistently
- adjust the homepage logo size so it matches other pages on mobile while remaining larger on desktop

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5466bd2cc832f88a1ce6f08fb6784