### PR TITLE
Refine homepage header visibility handling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -170,7 +170,7 @@ export default function Page() {
           <div className="mt-10 overflow-hidden">
             <div className="flex gap-4 whitespace-nowrap animate-[featureScroll_30s_linear_infinite]">
               {[
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -178,7 +178,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -186,7 +186,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",
@@ -194,7 +194,7 @@ export default function Page() {
                 "Etkili ve uygun fiyat politikası",
                 "Yüksek kalite standartları",
                 "Kapsamlı çözüm ortaklığı",
-                "30+ yıl deneyim",
+                "25+ yıl deneyim",
                 "50+ büyük ölçekli proje",
                 "Ulusal & uluslararası referanslar",
                 "Zamanında teslim ve servis",

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -52,93 +52,115 @@ export default function Header() {
     };
   }, [open]);
 
+  const renderDefaultHeader = (visibilityClass = "") => {
+    const withVisibility = (base: string) =>
+      visibilityClass ? `${visibilityClass} ${base}` : base;
+
+    return (
+      <>
+        {/* Üst bar yazılı */}
+        <div
+          className={withVisibility(
+            "bg-neutral-900 text-neutral-100 text-xs sm:text-sm"
+          )}
+        >
+          <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between">
+            <span className="hidden sm:flex items-center gap-1.5">
+              <Mail className="w-4 h-4" /> info@aykproje.com.tr
+            </span>
+            <span className="hidden md:flex items-center gap-1.5">
+              <MapPin className="w-4 h-4" /> Konuksever Mah. Emrah Cad. No:68/A,
+              Muratpaşa / Antalya
+            </span>
+          </div>
+        </div>
+
+        {/* Main bar */}
+        <div
+          className={withVisibility(
+            "backdrop-blur bg-white/80 border-b border-neutral-200"
+          )}
+        >
+          <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
+            <Link href="/" className="flex items-center gap-3">
+              <img
+                src="/assets/AYKlogo.webp"
+                alt="AYK Logo"
+                className="h-12 w-auto"
+              />
+              <span className="font-semibold text-neutral-800">
+                AYK Proje Elektrik
+              </span>
+            </Link>
+
+            <nav className="hidden md:flex items-center gap-6 text-sm ml-auto">
+              {LINKS.map((l) => (
+                <NavLink key={l.href} href={l.href}>
+                  {l.label}
+                </NavLink>
+              ))}
+            </nav>
+
+            <button
+              className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-xl border border-neutral-300 bg-white"
+              aria-label="Menüyü aç"
+              onClick={() => setOpen(true)}
+            >
+              <Menu className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const renderHomeDesktopHeader = () => (
+    <>
+      {/* İnce boş üst bar */}
+      <div className="hidden md:block h-5 bg-neutral-900" />
+
+      <div className="hidden md:block backdrop-blur bg-white/90 border-b border-neutral-200">
+        <div className="max-w-7xl mx-auto px-4 h-24 flex items-center justify-between">
+          {/* Logo tek başına */}
+          <Link href="/" className="flex items-center">
+            <img
+              src="/assets/AYKlogo.webp"
+              alt="AYK Logo"
+              className="h-20 w-auto"
+            />
+          </Link>
+
+          {/* Masaüstü menü */}
+          <nav className="hidden md:flex items-center gap-6 text-sm ml-auto">
+            {LINKS.map((l) => (
+              <NavLink key={l.href} href={l.href}>
+                {l.label}
+              </NavLink>
+            ))}
+          </nav>
+
+          {/* Hamburger */}
+          <button
+            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-xl border border-neutral-300 bg-white"
+            aria-label="Menüyü aç"
+            onClick={() => setOpen(true)}
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <header className="sticky top-0 z-40">
-      {/* === ANASAYFA HEADER === */}
       {isHome ? (
         <>
-          {/* İnce boş üst bar */}
-          <div className="h-5 bg-neutral-900" />
-
-          <div className="backdrop-blur bg-white/90 border-b border-neutral-200">
-            <div className="max-w-7xl mx-auto px-4 h-24 flex items-center justify-between">
-              {/* Logo tek başına */}
-              <Link href="/" className="flex items-center">
-                <img
-                  src="/assets/AYKlogo.webp"
-                  alt="AYK Logo"
-                  className="h-20 w-auto"
-                />
-              </Link>
-
-              {/* Masaüstü menü */}
-              <nav className="hidden md:flex items-center gap-6 text-sm ml-auto">
-                {LINKS.map((l) => (
-                  <NavLink key={l.href} href={l.href}>
-                    {l.label}
-                  </NavLink>
-                ))}
-              </nav>
-
-              {/* Hamburger */}
-              <button
-                className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-xl border border-neutral-300 bg-white"
-                aria-label="Menüyü aç"
-                onClick={() => setOpen(true)}
-              >
-                <Menu className="w-5 h-5" />
-              </button>
-            </div>
-          </div>
+          {renderDefaultHeader("md:hidden")}
+          {renderHomeDesktopHeader()}
         </>
       ) : (
-        /* === DİĞER SAYFALAR HEADER === */
-        <>
-          {/* Üst bar yazılı */}
-          <div className="bg-neutral-900 text-neutral-100 text-xs sm:text-sm">
-            <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between">
-              <span className="hidden sm:flex items-center gap-1.5">
-                <Mail className="w-4 h-4" /> info@aykproje.com.tr
-              </span>
-              <span className="hidden md:flex items-center gap-1.5">
-                <MapPin className="w-4 h-4" /> Konuksever Mah. Emrah Cad. No:68/A,
-                Muratpaşa / Antalya
-              </span>
-            </div>
-          </div>
-
-          {/* Main bar */}
-          <div className="backdrop-blur bg-white/80 border-b border-neutral-200">
-            <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
-              <Link href="/" className="flex items-center gap-3">
-                <img
-                  src="/assets/AYKlogo.webp"
-                  alt="AYK Logo"
-                  className="h-12 w-auto"
-                />
-                <span className="font-semibold text-neutral-800">
-                  AYK Proje Elektrik
-                </span>
-              </Link>
-
-              <nav className="hidden md:flex items-center gap-6 text-sm ml-auto">
-                {LINKS.map((l) => (
-                  <NavLink key={l.href} href={l.href}>
-                    {l.label}
-                  </NavLink>
-                ))}
-              </nav>
-
-              <button
-                className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-xl border border-neutral-300 bg-white"
-                aria-label="Menüyü aç"
-                onClick={() => setOpen(true)}
-              >
-                <Menu className="w-5 h-5" />
-              </button>
-            </div>
-          </div>
-        </>
+        renderDefaultHeader()
       )}
 
       {/* Mobil menü */}


### PR DESCRIPTION
## Summary
- add a visibility-aware helper so the homepage reuses the default header markup on mobile without extra wrappers
- keep the enlarged homepage logo limited to desktop by hiding the desktop-only header sections below the md breakpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5466bd2cc832f88a1ce6f08fb6784