### PR TITLE
Fix mailer URL sanitization

### DIFF
--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -31,11 +31,19 @@ const sanitizeConnectionUrl = (connectionUrl: string) => {
 
   // Normalize credentials (especially passwords) that may contain reserved characters
   // such as # or &. These characters break the URL parser unless they are encoded.
-  const match = trimmed.match(/^([^:]+):\/\/([^@]+)@(.*)$/);
-  if (!match) return trimmed;
+  const protocolSeparatorIndex = trimmed.indexOf("://");
+  if (protocolSeparatorIndex === -1) return trimmed;
 
-  const [, protocol, authPart, hostPart] = match;
-  const colonIndex = authPart.indexOf(":");
+  const protocol = trimmed.slice(0, protocolSeparatorIndex);
+  const remainder = trimmed.slice(protocolSeparatorIndex + 3);
+  const atIndex = remainder.lastIndexOf("@");
+  if (atIndex === -1) return trimmed;
+
+  const authPart = remainder.slice(0, atIndex);
+  const hostPart = remainder.slice(atIndex + 1);
+  if (!authPart || !hostPart) return trimmed;
+
+  const colonIndex = authPart.lastIndexOf(":");
   if (colonIndex === -1) return trimmed;
 
   const rawUser = authPart.slice(0, colonIndex);


### PR DESCRIPTION
## Summary
- update `sanitizeConnectionUrl` to split the connection string at the last `@` so usernames can contain `@`
- ensure credential parsing uses the last `:` before re-encoding the username and password

## Testing
- `node -e "const Module = require('module'); const path = require.resolve('nodemailer'); const stub = { createTransport: (url) => { const parsed = typeof url === 'string' ? new URL(url) : url; return { options: { auth: parsed.username ? { user: decodeURIComponent(parsed.username), pass: decodeURIComponent(parsed.password) } : undefined } }; } }; stub.default = stub; require.cache[path] = { exports: stub }; process.env.SMTP_URL='smtps://info@aykproje.com.tr:p#ss@mail.aykproje.com.tr:465'; const { getMailer } = require('./tmp/mailer.js'); const transporter = getMailer(); console.log(transporter.options.auth);"`
