### PR TITLE
Remove service URLs from sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,4 @@
 import { MetadataRoute } from "next";
-import { services } from "@/data/services";                // senin Services dosyan
 import { projectsWithPhotos } from "@/data/projects";      // senin Projects dosyan
 
 // İstersen domaini .env ile yönetecek şekilde yaz:
@@ -25,13 +24,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  // Hizmet sayfaları (services)
-  const servicePages: MetadataRoute.Sitemap = (services ?? []).map(s => ({
-    url: `${BASE_URL}/hizmetler/${s.slug}`,
-    lastModified: now,
-    changeFrequency: "monthly",
-    priority: 0.7,
-  }));
-
-  return [...staticPages, ...projectPages, ...servicePages];
+  return [...staticPages, ...projectPages];
 }


### PR DESCRIPTION
## Summary
- stop generating service detail URLs in the sitemap because the detail routes do not exist

## Testing
- npm run build *(fails: `next` command not found; dependency installation is blocked by 403 errors from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f1debfa4832f9129438c768b4f15