### PR TITLE
Update next-intl plugin configuration to v4 API

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,16 @@
-import {withNextIntl} from 'next-intl/plugin';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const locales = ['tr', 'en', 'de', 'ru', 'ar'];
+
+const withNextIntl = createNextIntlPlugin({
+  locales,
+  defaultLocale: 'tr',
+  localeDetection: true,
+  localePrefix: 'always'
+});
 
 const nextConfig = {
   reactStrictMode: true
 };
 
-export default withNextIntl({
-  locales,
-  defaultLocale: 'tr',
-  localeDetection: true,
-  localePrefix: 'always'
-})(nextConfig);
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- update the Next.js intl plugin integration to use the v4 `createNextIntlPlugin` factory
- ensure the plugin wrapper is applied to the exported Next.js configuration with existing locale settings

## Testing
- npm run build *(fails: missing next binary because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fb9e9a00832f977cddf1c2d166cb