### PR TITLE
Update next-intl plugin configuration to v4 API

### DIFF
--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,30 @@
+import {getRequestConfig} from 'next-intl/server';
+
+import {locales, type Locale} from '@/lib/i18n/config';
+
+const loadMessages = async (locale: Locale) => {
+  switch (locale) {
+    case 'tr':
+      return (await import('../messages/tr.json')).default;
+    case 'en':
+      return (await import('../messages/en.json')).default;
+    case 'de':
+      return (await import('../messages/de.json')).default;
+    case 'ru':
+      return (await import('../messages/ru.json')).default;
+    case 'ar':
+      return (await import('../messages/ar.json')).default;
+    default:
+      throw new Error(`Unsupported locale: ${locale}`);
+  }
+};
+
+export default getRequestConfig(async ({locale}) => {
+  if (!locales.includes(locale as Locale)) {
+    throw new Error(`Unsupported locale: ${locale}`);
+  }
+
+  return {
+    messages: await loadMessages(locale as Locale)
+  };
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,16 @@
-import {withNextIntl} from 'next-intl/plugin';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const locales = ['tr', 'en', 'de', 'ru', 'ar'];
+
+const withNextIntl = createNextIntlPlugin({
+  locales,
+  defaultLocale: 'tr',
+  localeDetection: true,
+  localePrefix: 'always'
+});
 
 const nextConfig = {
   reactStrictMode: true
 };
 
-export default withNextIntl({
-  locales,
-  defaultLocale: 'tr',
-  localeDetection: true,
-  localePrefix: 'always'
-})(nextConfig);
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- update the Next.js intl plugin integration to use the v4 `createNextIntlPlugin` factory
- ensure the plugin wrapper is applied to the exported Next.js configuration with existing locale settings
- add the v4-compatible `i18n/request.ts` loader so builds can resolve locale messages

## Testing
- npm run build *(fails: missing next binary because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fb9e9a00832f977cddf1c2d166cb