### PR TITLE
Fix next-intl server imports for v4 API

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,8 +4,8 @@ import type {ReactNode} from "react";
 import {NextIntlClientProvider} from "next-intl";
 import {
   getMessages,
-  getTranslator,
-  unstable_setRequestLocale,
+  getTranslations,
+  setRequestLocale,
 } from "next-intl/server";
 import {notFound} from "next/navigation";
 
@@ -38,7 +38,7 @@ export async function generateMetadata({
     notFound();
   }
 
-  const t = await getTranslator({locale, namespace: "layout"});
+  const t = await getTranslations({locale, namespace: "layout"});
   const title = t("meta.title");
   const description = t("meta.description");
   const template = t("meta.template");
@@ -83,7 +83,7 @@ export default async function LocaleLayout({
 
   const normalizedLocale = locale as Locale;
 
-  unstable_setRequestLocale(normalizedLocale);
+  setRequestLocale(normalizedLocale);
 
   const messages = await getMessages({locale: normalizedLocale});
 

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,30 @@
+import {getRequestConfig} from 'next-intl/server';
+
+import {locales, type Locale} from '@/lib/i18n/config';
+
+const loadMessages = async (locale: Locale) => {
+  switch (locale) {
+    case 'tr':
+      return (await import('../messages/tr.json')).default;
+    case 'en':
+      return (await import('../messages/en.json')).default;
+    case 'de':
+      return (await import('../messages/de.json')).default;
+    case 'ru':
+      return (await import('../messages/ru.json')).default;
+    case 'ar':
+      return (await import('../messages/ar.json')).default;
+    default:
+      throw new Error(`Unsupported locale: ${locale}`);
+  }
+};
+
+export default getRequestConfig(async ({locale}) => {
+  if (!locales.includes(locale as Locale)) {
+    throw new Error(`Unsupported locale: ${locale}`);
+  }
+
+  return {
+    messages: await loadMessages(locale as Locale)
+  };
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,16 @@
-import {withNextIntl} from 'next-intl/plugin';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const locales = ['tr', 'en', 'de', 'ru', 'ar'];
+
+const withNextIntl = createNextIntlPlugin({
+  locales,
+  defaultLocale: 'tr',
+  localeDetection: true,
+  localePrefix: 'always'
+});
 
 const nextConfig = {
   reactStrictMode: true
 };
 
-export default withNextIntl({
-  locales,
-  defaultLocale: 'tr',
-  localeDetection: true,
-  localePrefix: 'always'
-})(nextConfig);
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- update the locale layout to use the next-intl v4 `getTranslations` helper instead of the removed `getTranslator`
- switch to the stable `setRequestLocale` export so the request locale is registered during rendering

## Testing
- npm run build *(fails: Next CLI is unavailable because dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fb9e9a00832f977cddf1c2d166cb