### PR TITLE
Fix next-intl plugin configuration

### DIFF
--- a/app/aydinlatma-metni/page.tsx
+++ b/app/aydinlatma-metni/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "privacy" });
+  const t = await getTranslations("privacy");
   const purposes = t.raw("sections.purposes.items") as string[];
   const footerText = `${t("footer.text")} `;
   const footerLink = t("footer.link");

--- a/app/hakkimizda/page.tsx
+++ b/app/hakkimizda/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "about" });
+  const t = await getTranslations("about");
   const statsMessages = t.raw("stats") as Record<string, string>;
   const whyItems = t.raw("why.items") as string[];
   const valuesItems = t.raw("values.items") as string[];

--- a/app/hizmetler/page.tsx
+++ b/app/hizmetler/page.tsx
@@ -25,7 +25,7 @@ const iconMap: Record<string, ReactElement> = {
 };
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "services" });
+  const t = await getTranslations("services");
   const cardMessages = t.raw("cards") as Record<
     string,
     { title: string; desc: string; bullets?: string[] }

--- a/app/iletisim/page.tsx
+++ b/app/iletisim/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "contact" });
+  const t = await getTranslations("contact");
   const socialLinks = t.raw("social.links") as Record<string, string>;
   return (
     <section className="py-10 md:py-14">

--- a/app/kvkk/page.tsx
+++ b/app/kvkk/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "kvkk" });
+  const t = await getTranslations("kvkk");
   const rights = t.raw("sections.rights.items") as string[];
   const controllerBody = `${t("sections.controller.body")} `;
   const controllerLink = t("sections.controller.link");

--- a/app/projeler/[slug]/page.tsx
+++ b/app/projeler/[slug]/page.tsx
@@ -13,8 +13,8 @@ export const dynamicParams = false;
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const [tDetail, tProjects] = await Promise.all([
-    getTranslations({ namespace: "projects_detail" }),
-    getTranslations({ namespace: "projects" }),
+    getTranslations("projects_detail"),
+    getTranslations("projects"),
   ]);
   const p = projectsWithPhotos.find((x) => x.slug === params.slug);
   if (!p) return notFound();

--- a/app/projeler/page.tsx
+++ b/app/projeler/page.tsx
@@ -24,7 +24,7 @@ function splitCategoryYear(cat: string): { cat: string; year: string } {
 }
 
 export default async function Page() {
-  const t = await getTranslations({ namespace: "projects" });
+  const t = await getTranslations("projects");
   const cardMessages = t.raw("items") as Record<string, { title: string; desc: string }>;
   return (
     <section className="py-10 md:py-14">

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,13 +2,6 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
-const withNextIntl = createNextIntlPlugin({
-  locales,
-  defaultLocale: 'tr',
-  localeDetection: true,
-  localePrefix: 'always'
-});
-
 const nextConfig = {
   reactStrictMode: true
 };


### PR DESCRIPTION
## Summary
- configure next-intl plugin using the existing request handler so there is a single plugin wrapper in `next.config.mjs`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d803a8a170832faf8109e6b72345b7