### PR TITLE
fix: remove unsupported pathname parser import

### DIFF
--- a/lib/i18n/routing.ts
+++ b/lib/i18n/routing.ts
@@ -1,4 +1,4 @@
-import {createNavigation, createPathnameParser} from 'next-intl/navigation';
+import {createNavigation} from 'next-intl/navigation';
 
 import {i18nConfig} from './config';
 
@@ -17,8 +17,3 @@ export const {
   localePrefix: i18nConfig.localePrefix
 });
 
-export const {parsePathname} = createPathnameParser({
-  locales: i18nConfig.locales,
-  defaultLocale: i18nConfig.defaultLocale,
-  localePrefix: i18nConfig.localePrefix
-});


### PR DESCRIPTION
## Summary
- stop importing `createPathnameParser` from `next-intl/navigation` because it is not provided by the installed `next-intl` version
- retain the existing navigation helpers generated by `createNavigation`

## Testing
- `npm run build` *(fails: pre-existing type error in app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d82b5cd9e4832f9cbac6ecdc7af16e