### PR TITLE
Exclude assets from intl middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,6 @@ export default createMiddleware({
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|manifest.json).*)'
+    '/((?!api|_next/static|_next/image|assets|favicon.ico|robots.txt|sitemap.xml|manifest.json).*)'
   ]
 };


### PR DESCRIPTION
## Summary
- exclude /assets paths from the internationalization middleware matcher so static images are no longer rewritten

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d831932644832fb552b43006df14cb