### PR TITLE
Add locale-prefixed routes for site pages

### DIFF
--- a/app/[locale]/aydinlatma-metni/page.tsx
+++ b/app/[locale]/aydinlatma-metni/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../aydinlatma-metni/page";
+export {generateMetadata} from "../../aydinlatma-metni/page";

--- a/app/[locale]/hakkimizda/page.tsx
+++ b/app/[locale]/hakkimizda/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../hakkimizda/page";
+export {generateMetadata} from "../../hakkimizda/page";

--- a/app/[locale]/hizmetler/page.tsx
+++ b/app/[locale]/hizmetler/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../hizmetler/page";
+export {generateMetadata} from "../../hizmetler/page";

--- a/app/[locale]/iletisim/page.tsx
+++ b/app/[locale]/iletisim/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../iletisim/page";
+export {generateMetadata} from "../../iletisim/page";

--- a/app/[locale]/kvkk/page.tsx
+++ b/app/[locale]/kvkk/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../kvkk/page";
+export {generateMetadata} from "../../kvkk/page";

--- a/app/[locale]/projeler/[slug]/page.tsx
+++ b/app/[locale]/projeler/[slug]/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../../projeler/[slug]/page";
+export {generateStaticParams, dynamicParams} from "../../../projeler/[slug]/page";

--- a/app/[locale]/projeler/page.tsx
+++ b/app/[locale]/projeler/page.tsx
@@ -1,0 +1,2 @@
+export {default} from "../../projeler/page";
+export {generateMetadata} from "../../projeler/page";


### PR DESCRIPTION
## Summary
- expose localized routes for about, services, projects, contact, KVKK and lighting pages
- add locale-prefixed routing for individual project detail pages

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d83718d9f4832fab82a5f7a83513af